### PR TITLE
Add missing 'u' subscript

### DIFF
--- a/01-Foundations.Rmd
+++ b/01-Foundations.Rmd
@@ -688,8 +688,8 @@ A bivariate distribution for two random variables $X$ and $Y$, each of which com
 \Sigma
 =
 \begin{pmatrix}
-\sigma _{x}^2  & \rho\sigma _{x}\sigma _{y}\\
-\rho\sigma _{x}\sigma _{y}    & \sigma _{y}^2\\
+\sigma _{x}^2  & \rho_u\sigma _{x}\sigma _{y}\\
+\rho_u\sigma _{x}\sigma _{y}    & \sigma _{y}^2\\
 \end{pmatrix}
 \end{equation}
 


### PR DESCRIPTION
In 1.4.2, you introduce the subscript $u$ for $\rho$. However, in the formal notation of the variance-covariance matrix, only $\rho$ is defined (so without the $u$). I assume this is a mistake? I corrected it in this PR.

![image](https://user-images.githubusercontent.com/84721952/194541662-c854875c-e6d6-4808-a011-4a4e8c83f93d.png)

Thanks for making the book available for everyone!